### PR TITLE
Add 1-argument `ensure!($expr)`

### DIFF
--- a/eyre/src/macros.rs
+++ b/eyre/src/macros.rs
@@ -107,6 +107,11 @@ macro_rules! bail {
 /// ```
 #[macro_export]
 macro_rules! ensure {
+    ($cond:expr $(,)?) => {
+        if !$cond {
+            $crate::ensure!($cond, concat!("Condition failed: `", stringify!($cond), "`"))
+        }
+    };
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {
             return $crate::private::Err($crate::eyre!($msg));

--- a/eyre/tests/test_macros.rs
+++ b/eyre/tests/test_macros.rs
@@ -39,6 +39,15 @@ fn test_ensure() {
         Ok(())
     };
     assert!(f().is_err());
+
+    let f = || {
+        ensure!(v + v == 1);
+        Ok(())
+    };
+    assert_eq!(
+        f().unwrap_err().to_string(),
+        "Condition failed: `v + v == 1`",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Amends a subltle difference from `anyhow`. This PR is basically duplicated from https://github.com/dtolnay/anyhow/pull/129.