### PR TITLE
Add `eyre::Ok`

### DIFF
--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -709,7 +709,7 @@ pub trait EyreHandler: core::any::Any + Send + Sync {
             }
         }
 
-        Ok(())
+        Result::Ok(())
     }
 
     /// Store the location of the caller who constructed this error report
@@ -831,7 +831,7 @@ impl EyreHandler for DefaultHandler {
             }
         }
 
-        Ok(())
+        Result::Ok(())
     }
 
     #[cfg(track_caller)]
@@ -1191,6 +1191,29 @@ pub trait ContextCompat<T>: context::private::Sealed {
     where
         D: Display + Send + Sync + 'static,
         F: FnOnce() -> D;
+}
+
+/// Equivalent to Ok::<_, eyre::Error>(value).
+///
+/// This simplifies creation of an eyre::Result in places where type inference
+/// cannot deduce the `E` type of the result &mdash; without needing to write
+/// `Ok::<_, eyre::Error>(value)`.
+///
+/// One might think that `eyre::Result::Ok(value)` would work in such cases
+/// but it does not.
+///
+/// ```console
+/// error[E0282]: type annotations needed for `std::result::Result<i32, E>`
+///   --> src/main.rs:11:13
+///    |
+/// 11 |     let _ = eyre::Result::Ok(1);
+///    |         -   ^^^^^^^^^^^^^^^^ cannot infer type for type parameter `E` declared on the enum `Result`
+///    |         |
+///    |         consider giving this pattern the explicit type `std::result::Result<i32, E>`, where the type parameter `E` is specified
+/// ```
+#[allow(non_snake_case)]
+pub fn Ok<T>(t: T) -> Result<T> {
+    Result::Ok(t)
 }
 
 // Not public API. Referenced by macro-generated code.


### PR DESCRIPTION
This PR is a backport of the [`anyhow::Ok`](https://docs.rs/anyhow/latest/anyhow/fn.Ok.html) function (https://github.com/dtolnay/anyhow/issues/192). For motivation, consider the following minimal example:

```rust
fn main() -> eyre::Result<()> {
    let f = || eyre::Ok(());

    f()?;

    Ok(())
}
```

Without this `Ok`, function, the next best way to write line 2 would be `let f = || Result::<_, eyre::Error>::Ok(());`, which is quite verbose! `anyhow::Ok` is probably the biggest pain point I've had in the cases where I've used `eyre` in place of `anyhow`.