### PR TITLE
Automatically convert to external errors w/ ensure! and bail!

### DIFF
--- a/eyre/src/macros.rs
+++ b/eyre/src/macros.rs
@@ -51,13 +51,13 @@
 #[macro_export]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::private::Err($crate::eyre!($msg));
+        return $crate::private::Err($crate::eyre!($msg).into());
     };
     ($err:expr $(,)?) => {
-        return $crate::private::Err($crate::eyre!($err));
+        return $crate::private::Err($crate::eyre!($err).into());
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::private::Err($crate::eyre!($fmt, $($arg)*));
+        return $crate::private::Err($crate::eyre!($fmt, $($arg)*).into());
     };
 }
 
@@ -114,17 +114,17 @@ macro_rules! ensure {
     };
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::eyre!($msg));
+            return $crate::private::Err($crate::eyre!($msg).into());
         }
     };
     ($cond:expr, $err:expr $(,)?) => {
         if !$cond {
-            return $crate::private::Err($crate::eyre!($err));
+            return $crate::private::Err($crate::eyre!($err).into());
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)*) => {
         if !$cond {
-            return $crate::private::Err($crate::eyre!($fmt, $($arg)*));
+            return $crate::private::Err($crate::eyre!($fmt, $($arg)*).into());
         }
     };
 }

--- a/eyre/tests/test_macros.rs
+++ b/eyre/tests/test_macros.rs
@@ -40,6 +40,7 @@ fn test_ensure() {
     };
     assert!(f().is_err());
 
+    // Tests single-argument `ensure!`
     let f = || {
         ensure!(v + v == 1);
         Ok(())
@@ -48,6 +49,23 @@ fn test_ensure() {
         f().unwrap_err().to_string(),
         "Condition failed: `v + v == 1`",
     );
+
+    // Tests automatically converting to external errors with ensure!()
+    let f = || -> Result<(), SomeWrappingErr> {
+        ensure!(false, "this will fail");
+        Ok(())
+    };
+    assert!(f().is_err());
+}
+
+struct SomeWrappingErr {
+    err: eyre::Error,
+}
+
+impl From<eyre::Error> for SomeWrappingErr {
+    fn from(err: eyre::Error) -> Self {
+        SomeWrappingErr { err }
+    }
 }
 
 #[test]

--- a/eyre/tests/test_macros.rs
+++ b/eyre/tests/test_macros.rs
@@ -41,7 +41,7 @@ fn test_ensure() {
     assert!(f().is_err());
 
     // Tests single-argument `ensure!`
-    let f = || {
+    let f = || -> Result<()> {
         ensure!(v + v == 1);
         Ok(())
     };
@@ -58,6 +58,7 @@ fn test_ensure() {
     assert!(f().is_err());
 }
 
+#[allow(dead_code)]
 struct SomeWrappingErr {
     err: eyre::Error,
 }


### PR DESCRIPTION
A pattern documented by thiserror is

```
pub enum MyError {
  ...

  #[error(transparent)]
  Other(#[from] anyhow::Error), // source and Display delegate to anyhow::Error
}
```

It'd be nice for this to work with ensure! but right now, that macro returns an eyre error. There's the 'ScienceError' example but that is more for the case where you want to pick a specific enum variant.

With this PR, the macro additionally runs an .into(). In the case that the return type is an eyre error, obviously .into() will do nothing and be compiled away. In the case that there is a from method, the wrapping will occur. This enables eyre to be used for ergonomic 'implementation detail error' in a thiserror using system which has contractual errors. In the above case, one could write:

```rust
fn foo() -> Result<(), MyError> {
  ensure!(false, "this will be wrapped up in a MyError");
  Ok(())
}
```

To the best of my knowledge, this is a non-breaking change. I also considered modifying `eyre!` to add the .into(), however that seemed more likely to be a breaking change (in particular, breaking `eyre!("foo").into()`!).