### PR TITLE
Move missing_doc_code_examples lint behind its feature gate

### DIFF
--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -60,10 +60,14 @@
 //! [`tracing_error::SpanTrace`]: https://docs.rs/tracing-error/*/tracing_error/struct.SpanTrace.html
 //! [`color-backtrace`]: https://github.com/athre0z/color-backtrace
 #![doc(html_root_url = "https://docs.rs/color-spantrace/0.2.0")]
+#![cfg_attr(
+    nightly_features,
+    feature(rustdoc_missing_doc_code_examples),
+    warn(rustdoc::missing_doc_code_examples)
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,
-    rustdoc::missing_doc_code_examples,
     rust_2018_idioms,
     unreachable_pub,
     bad_style,

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -329,11 +329,14 @@
 //! [`color-spantrace`]: https://github.com/eyre-rs/color-spantrace
 //! [`color-backtrace`]: https://github.com/athre0z/color-backtrace
 #![doc(html_root_url = "https://docs.rs/eyre/0.6.8")]
+#![cfg_attr(
+    nightly_features,
+    feature(rustdoc_missing_doc_code_examples),
+    warn(rustdoc::missing_doc_code_examples)
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,
-    // FIXME: this lint is currently nightly only
-    rustdoc::missing_doc_code_examples,
     unsafe_op_in_unsafe_fn,
     rust_2018_idioms,
     unreachable_pub,

--- a/eyre/tests/test_toolchain.rs
+++ b/eyre/tests/test_toolchain.rs
@@ -1,0 +1,17 @@
+#[rustversion::attr(not(nightly), ignore)]
+//#[cfg_attr(miri, ignore)]
+#[test]
+fn nightlytest() {
+    if !cfg!(nightly_features) {
+        panic!("nightly feature isn't set when the toolchain is nightly");
+    }
+}
+
+#[rustversion::attr(nightly, ignore)]
+//#[cfg_attr(miri, ignore)]
+#[test]
+fn stabletest() {
+    if cfg!(nightly_features) {
+        panic!("nightly feature is set when the toolchain isn't nightly");
+    }
+}


### PR DESCRIPTION
CI has been failing due to using the nightly-only
rustdoc_missing_doc_code_examples lint unconditionally.

This moves it behind its feature gate and removes many warnings due to unknown lint.