### PR TITLE
Remove obsolete private_in_public lint in nightly.

### DIFF
--- a/color-spantrace/build.rs
+++ b/color-spantrace/build.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::ffi::OsString;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    let version = match rustc_version_info() {
+        Some(version) => version,
+        None => return,
+    };
+    version.toolchain.set_feature();
+}
+
+#[derive(PartialEq)]
+enum Toolchain {
+    Stable,
+    Beta,
+    Nightly,
+}
+
+impl Toolchain {
+    fn set_feature(self) {
+        match self {
+            Toolchain::Nightly => println!("cargo:rustc-cfg=nightly"),
+            Toolchain::Beta => println!("cargo:rustc-cfg=beta"),
+            Toolchain::Stable => println!("cargo:rustc-cfg=stable"),
+        }
+    }
+}
+
+struct VersionInfo {
+    toolchain: Toolchain,
+}
+
+fn rustc_version_info() -> Option<VersionInfo> {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split(['.', ' ', '-']);
+    if pieces.next() != Some("rustc") {
+        return None;
+    }
+    let _major: u32 = pieces.next()?.parse().ok()?;
+    let _minor: u32 = pieces.next()?.parse().ok()?;
+    let _patch: u32 = pieces.next()?.parse().ok()?;
+    let toolchain = match pieces.next() {
+        Some("beta") => Toolchain::Beta,
+        Some("nightly") => Toolchain::Nightly,
+        _ => Toolchain::Stable,
+    };
+    let version = VersionInfo { toolchain };
+    Some(version)
+}

--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -61,10 +61,11 @@
 //! [`color-backtrace`]: https://github.com/athre0z/color-backtrace
 #![doc(html_root_url = "https://docs.rs/color-spantrace/0.2.0")]
 #![cfg_attr(
-    nightly_features,
+    nightly,
     feature(rustdoc_missing_doc_code_examples),
     warn(rustdoc::missing_doc_code_examples)
 )]
+#![cfg_attr(stable, warn(private_in_public))]
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -78,7 +79,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -316,10 +316,11 @@
 //! [`color-backtrace`]: https://github.com/athre0z/color-backtrace
 #![doc(html_root_url = "https://docs.rs/eyre/0.6.8")]
 #![cfg_attr(
-    nightly_features,
+    nightly,
     feature(rustdoc_missing_doc_code_examples),
     warn(rustdoc::missing_doc_code_examples)
 )]
+#![cfg_attr(stable, warn(private_in_public))]
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -334,7 +335,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/eyre/tests/test_toolchain.rs
+++ b/eyre/tests/test_toolchain.rs
@@ -1,17 +1,34 @@
+// These tests check our build script against rustversion.
+
 #[rustversion::attr(not(nightly), ignore)]
-//#[cfg_attr(miri, ignore)]
 #[test]
 fn nightlytest() {
-    if !cfg!(nightly_features) {
-        panic!("nightly feature isn't set when the toolchain is nightly");
+    if !cfg!(nightly) {
+        panic!("nightly feature isn't set when the toolchain is nightly.");
+    }
+    if cfg!(any(beta, stable)) {
+        panic!("beta, stable, and nightly are mutually exclusive features.")
     }
 }
 
-#[rustversion::attr(nightly, ignore)]
-//#[cfg_attr(miri, ignore)]
+#[rustversion::attr(not(beta), ignore)]
+#[test]
+fn betatest() {
+    if !cfg!(beta) {
+        panic!("beta feature is not set when the toolchain is beta.");
+    }
+    if cfg!(any(nightly, stable)) {
+        panic!("beta, stable, and nightly are mutually exclusive features.")
+    }
+}
+
+#[rustversion::attr(not(stable), ignore)]
 #[test]
 fn stabletest() {
-    if cfg!(nightly_features) {
-        panic!("nightly feature is set when the toolchain isn't nightly");
+    if !cfg!(stable) {
+        panic!("stable feature is not set when the toolchain is stable.");
+    }
+    if cfg!(any(nightly, beta)) {
+        panic!("beta, stable, and nightly are mutually exclusive features.")
     }
 }


### PR DESCRIPTION
RFC 2145 is on nightly now, deprecating the public_in_private lint. https://rust-lang.github.io/rfcs/2145-type-privacy.html

public_in_private has been superceded by three new lints. The first two are warn-by-default and the third is allow-by-default. See the excerpt below for some details.

This change skips this lint in nightly in favor of the new warn-by-default lints.

This change revealed a bug in the 'nightly_features' config option for color-spantrace -- it doesn't exist! The lint it was guarding was never turned on. This adds a minimal build script to check for nightly to color-spantrace. Its functionality is tested in the eyre crate, which seems sufficient to me.

The proof this works is that it builds without the warning in nightly : )

After this change there are only two more build warnings for eyre and color-spantrace, the future-incompat dependency warning and the more serious filename collision.

<quote>
    Lint private_interfaces is reported when a type with visibility x is
    used in primary interface of an item with effective visibility y and
    x < y. This lint is warn-by-default.

    Lint private_bounds is reported when a type or trait with visibility
    x is used in secondary interface of an item with effective
    visibility y and x < y. This lint is warn-by-default.

    Lint unnameable_types is reported when effective visibility of a
    type is larger than module in which it can be named, either
    directly, or through reexports, or through trivial type aliases
    (type X = Y;, no generics on both sides). This lint is
    allow-by-default.

    Compatibility lint private_in_public is never reported and removed.
</quote>