### PR TITLE
Update future-incompat pyo3 dependency

### DIFF
--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -20,7 +20,7 @@ track-caller = []
 [dependencies]
 indenter = { workspace = true }
 once_cell = { workspace = true }
-pyo3 = { version = "0.13", optional = true, default-features = false }
+pyo3 = { version = "0.20", optional = true, default-features = false }
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false }
@@ -30,7 +30,7 @@ trybuild = { version = "1.0.19", features = ["diff"] }
 backtrace = "0.3.46"
 anyhow = "1.0.28"
 syn = { version = "2.0", features = ["full"] }
-pyo3 = { version = "0.13", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.20", default-features = false, features = ["auto-initialize"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/eyre/tests/test_pyo3.rs
+++ b/eyre/tests/test_pyo3.rs
@@ -28,6 +28,6 @@ fn test_pyo3_exception_contents() {
     Python::with_gil(|py| {
         let locals = [("err", pyerr)].into_py_dict(py);
         let pyerr = py.run("raise err", None, Some(locals)).unwrap_err();
-        assert_eq!(pyerr.pvalue(py).to_string(), expected_contents);
+        assert_eq!(pyerr.value(py).to_string(), expected_contents);
     })
 }


### PR DESCRIPTION
pyo3 v0.13.2 is tripping future-incompat. This change updates it to the newest 0.20.

The other future-incompat dependency, nom, is an indirect dependency through ansi-parser.

See issue #116