### PR TITLE
Remove public_in_private warning

### DIFF
--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -65,7 +65,6 @@
     feature(rustdoc_missing_doc_code_examples),
     warn(rustdoc::missing_doc_code_examples)
 )]
-#![cfg_attr(stable, warn(private_in_public))]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -320,7 +320,6 @@
     feature(rustdoc_missing_doc_code_examples),
     warn(rustdoc::missing_doc_code_examples)
 )]
-#![cfg_attr(stable, warn(private_in_public))]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
RFC #3516 has been merged and the public in private changes are on stable. It's tripping clippy on stable, so let's fully remove it from our codebase.