### PR TITLE
Except doc files from CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
+      - '**/LICENSE*'
     branches:
       - master
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/LICENSE*'
 
 name: Continuous integration
 


### PR DESCRIPTION
Running CI over changing the README is a waste! I just tested this in a personal repo of mine and was delighted that it works. I can't demonstrate that it works in this pull request 'on pull request' considers all files changed in the PR and this change necessarily changes the ci.yml, but I can show where it's worked elsewhere.