### PR TITLE
Extend `Option` with `ok_or_eyre`

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,24 +208,30 @@ implies that you're creating a new error that saves the old error as its
 `source`. With `Option` there is no source error to wrap, so `wrap_err` ends up
 being somewhat meaningless.
 
-Instead `eyre` intends for users to use the combinator functions provided by
-`std` for converting `Option`s to `Result`s. So where you would write this with
+Instead `eyre` offers [`OptionExt::ok_or_eyre`] to yield _static_ errors from `None`,
+and intends for users to use the combinator functions provided by
+`std`, converting `Option`s to `Result`s, for _dynamic_ errors.
+So where you would write this with
 anyhow:
+
+[`OptionExt::ok_or_eyre`]: https://docs.rs/eyre/latest/eyre/trait.OptionExt.html#tymethod.ok_or_eyre
 
 ```rust
 use anyhow::Context;
 
 let opt: Option<()> = None;
-let result = opt.context("new error message");
+let result_static = opt.context("static error message");
+let result_dynamic = opt.with_context(|| format!("{} error message", "dynamic"));
 ```
 
 With `eyre` we want users to write:
 
 ```rust
-use eyre::{eyre, Result};
+use eyre::{eyre, OptionExt, Result};
 
 let opt: Option<()> = None;
-let result: Result<()> = opt.ok_or_else(|| eyre!("new error message"));
+let result_static: Result<()> = opt.ok_or_eyre("static error message");
+let result_dynamic: Result<()> = opt.ok_or_else(|| eyre!("{} error message", "dynamic"));
 ```
 
 **NOTE**: However, to help with porting we do provide a `ContextCompat` trait which

--- a/eyre/CHANGELOG.md
+++ b/eyre/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Added
+- Add `OptionExt::ok_or_eyre` for yielding static `Report`s from `None` [by LeoniePhiline](https://github.com/eyre-rs/eyre/pull/125)
 
 ## [0.6.9] - 2023-11-17
 ### Fixed

--- a/eyre/src/option.rs
+++ b/eyre/src/option.rs
@@ -1,0 +1,14 @@
+use crate::OptionExt;
+use core::fmt::{Debug, Display};
+
+impl<T> OptionExt<T> for Option<T> {
+    fn ok_or_eyre<M>(self, message: M) -> crate::Result<T>
+    where
+        M: Debug + Display + Send + Sync + 'static,
+    {
+        match self {
+            Some(ok) => Ok(ok),
+            None => Err(crate::Report::msg(message)),
+        }
+    }
+}

--- a/eyre/tests/test_option.rs
+++ b/eyre/tests/test_option.rs
@@ -1,0 +1,15 @@
+mod common;
+
+use self::common::maybe_install_handler;
+use eyre::OptionExt;
+
+#[test]
+fn test_option_ok_or_eyre() {
+    maybe_install_handler().unwrap();
+
+    let option: Option<()> = None;
+
+    let result = option.ok_or_eyre("static str error");
+
+    assert_eq!(result.unwrap_err().to_string(), "static str error");
+}


### PR DESCRIPTION
Previously, a closure and macro invocation was
required to generate a static string error object
from an `Option::None`.

This change adds an extension trait, providing
the `ok_or_eyre` method on the `Option` type.

`Option::ok_or_eyre` accepts static error messages
and creates `Report` objects lazily in the `None` case.

Implements #125