### PR TITLE
fix: `ok_or_eyre` not using `track_caller`

### DIFF
--- a/eyre/src/option.rs
+++ b/eyre/src/option.rs
@@ -2,6 +2,7 @@ use crate::OptionExt;
 use core::fmt::{Debug, Display};
 
 impl<T> OptionExt<T> for Option<T> {
+    #[track_caller]
     fn ok_or_eyre<M>(self, message: M) -> crate::Result<T>
     where
         M: Debug + Display + Send + Sync + 'static,

--- a/eyre/tests/test_location.rs
+++ b/eyre/tests/test_location.rs
@@ -1,6 +1,6 @@
 use std::panic::Location;
 
-use eyre::WrapErr;
+use eyre::{OptionExt as _, WrapErr};
 
 struct LocationHandler {
     actual: Option<&'static str>,
@@ -78,6 +78,19 @@ fn test_wrap_err_with() {
     let err = read_path("totally_fake_path")
         .wrap_err_with(|| "oopsie")
         .unwrap_err();
+
+    // should panic if the location isn't in our crate
+    println!("{:?}", err);
+}
+
+#[test]
+fn test_option_ok_or_eyre() {
+    let _ = eyre::set_hook(Box::new(|_e| {
+        let expected_location = file!();
+        Box::new(LocationHandler::new(expected_location))
+    }));
+
+    let err = None::<()>.ok_or_eyre("oopsie").unwrap_err();
 
     // should panic if the location isn't in our crate
     println!("{:?}", err);


### PR DESCRIPTION
`ok_or_eyre` did not use `track_caller`, which meant the error location was incorrect compared to the equivalent anyhow::context feature