### PR TITLE
Fix invalid drop impl call in `Report::downcast`

### DIFF
--- a/eyre/src/error.rs
+++ b/eyre/src/error.rs
@@ -698,13 +698,13 @@ where
     // ptr::read to take ownership of that value.
     if TypeId::of::<D>() == target {
         unsafe {
-            e.cast::<ErrorImpl<ContextError<ManuallyDrop<E>, E>>>()
+            e.cast::<ErrorImpl<ContextError<ManuallyDrop<D>, E>>>()
                 .into_box()
         };
     } else {
         debug_assert_eq!(TypeId::of::<E>(), target);
         unsafe {
-            e.cast::<ErrorImpl<ContextError<E, ManuallyDrop<E>>>>()
+            e.cast::<ErrorImpl<ContextError<D, ManuallyDrop<E>>>>()
                 .into_box()
         };
     }

--- a/eyre/tests/drop/mod.rs
+++ b/eyre/tests/drop/mod.rs
@@ -24,11 +24,13 @@ impl Flag {
 #[derive(Debug)]
 pub struct DetectDrop {
     has_dropped: Flag,
+    label: &'static str,
 }
 
 impl DetectDrop {
-    pub fn new(has_dropped: &Flag) -> Self {
+    pub fn new(label: &'static str, has_dropped: &Flag) -> Self {
         DetectDrop {
+            label,
             has_dropped: Flag {
                 atomic: Arc::clone(&has_dropped.atomic),
             },
@@ -46,6 +48,7 @@ impl Display for DetectDrop {
 
 impl Drop for DetectDrop {
     fn drop(&mut self) {
+        eprintln!("Dropping {}", self.label);
         let already_dropped = self.has_dropped.atomic.swap(true, SeqCst);
         assert!(!already_dropped);
     }

--- a/eyre/tests/test_convert.rs
+++ b/eyre/tests/test_convert.rs
@@ -11,7 +11,7 @@ fn test_convert() {
     maybe_install_handler().unwrap();
 
     let has_dropped = Flag::new();
-    let error: Report = Report::new(DetectDrop::new(&has_dropped));
+    let error: Report = Report::new(DetectDrop::new("TestConvert", &has_dropped));
     let box_dyn = Box::<dyn StdError + Send + Sync>::from(error);
     assert_eq!("oh no!", box_dyn.to_string());
     drop(box_dyn);

--- a/eyre/tests/test_downcast.rs
+++ b/eyre/tests/test_downcast.rs
@@ -109,7 +109,7 @@ fn test_drop() {
     maybe_install_handler().unwrap();
 
     let has_dropped = Flag::new();
-    let error: Report = Report::new(DetectDrop::new(&has_dropped));
+    let error: Report = Report::new(DetectDrop::new("DetectDrop", &has_dropped));
     drop(error.downcast::<DetectDrop>().unwrap());
     assert!(has_dropped.get());
 }

--- a/eyre/tests/test_repr.rs
+++ b/eyre/tests/test_repr.rs
@@ -31,6 +31,6 @@ fn test_drop() {
     maybe_install_handler().unwrap();
 
     let has_dropped = Flag::new();
-    drop(Report::new(DetectDrop::new(&has_dropped)));
+    drop(Report::new(DetectDrop::new("TestDrop", &has_dropped)));
     assert!(has_dropped.get());
 }


### PR DESCRIPTION
The context chain downcast called converted to the wrong inner type which caused the wrong drop impl to be called.

The tests did not catch this because they had compatible drop implementations due to matching type layout. Solved by swizzling the fields of the chain test types to force incompatible layouts

Resolves: #141