### PR TITLE
Bump version 1.0.0

### DIFF
--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eyre"
-version = "0.6.11"
+version = "1.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>", "Jane Lusby <jlusby42@gmail.com>"]
 description = "Flexible concrete Error Reporting type built on std::error::Error with customizable Reports"
 documentation = "https://docs.rs/eyre"


### PR DESCRIPTION
Prepares for a stable `1.0.0` release.

This release would signify the start of a stability commitment, and allow us to update APIs to be reflictive or the current state and things which we have learnt since.

@yaahc, I would like to request your signoff on this :)