### PR TITLE
fix: remove `anyhow` feature flag from `OptionExt` location test 

### DIFF
--- a/eyre/tests/test_location.rs
+++ b/eyre/tests/test_location.rs
@@ -83,7 +83,6 @@ fn test_wrap_err_with() {
     println!("{:?}", err);
 }
 
-#[cfg(feature = "anyhow")]
 #[test]
 fn test_option_ok_or_eyre() {
     let _ = eyre::set_hook(Box::new(|_e| {

--- a/eyre/tests/test_location.rs
+++ b/eyre/tests/test_location.rs
@@ -1,7 +1,5 @@
 use std::panic::Location;
 
-use eyre::WrapErr;
-
 struct LocationHandler {
     actual: Option<&'static str>,
     expected: &'static str,
@@ -46,6 +44,7 @@ fn test_wrap_err() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
+    use eyre::WrapErr;
     let err = read_path("totally_fake_path")
         .wrap_err("oopsie")
         .unwrap_err();
@@ -75,6 +74,7 @@ fn test_wrap_err_with() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
+    use eyre::WrapErr;
     let err = read_path("totally_fake_path")
         .wrap_err_with(|| "oopsie")
         .unwrap_err();
@@ -106,6 +106,7 @@ fn test_context() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
+    use eyre::WrapErr;
     let err = read_path("totally_fake_path")
         .context("oopsie")
         .unwrap_err();
@@ -122,6 +123,7 @@ fn test_with_context() {
         Box::new(LocationHandler::new(expected_location))
     }));
 
+    use eyre::WrapErr;
     let err = read_path("totally_fake_path")
         .with_context(|| "oopsie")
         .unwrap_err();


### PR DESCRIPTION
# 1. Clarify trait usage in location test

[`8522f02`](https://github.com/eyre-rs/eyre/pull/148/commits/8522f02518330d4a0178a0e940c4a910bb9299e0) 

Both `WrapErr` and `ContextCompat` expose `anyhow` compatibility methods.

- `ContextCompat` is completely feature gated behind the `anyhow` flag.

- `WrapErr`, on the other hand, feature-gates individual functions behind the `anyhow` flag.

This has led to [confusion][confusion] in the past.

This change moves the `use eyre::WrapErr` statement from the top of the module into each individual test, as [identically named functions](https://github.com/eyre-rs/eyre/issues/149) (`wrap_err.*`) are exposed both by `WrapErr` and `ContextCompat`.

With `use eyre::WrapErr` moved directly into the tests, it becomes clear which trait-provided `fn` is being called.

[confusion]: https://github.com/eyre-rs/eyre/pull/138#discussion_r1432909562

# 2. Remove `anyhow` feature flag from `OptionExt` location test 

[`68744f1`](https://github.com/eyre-rs/eyre/commit/68744f19fb5f755aafdee2b163510b2e4e1fca37) 

This bug was introduced (by me) in https://github.com/eyre-rs/eyre/commit/34bd1d98937d775dc8916a638d7ac0eece9e6e97#diff-1ff47dac6cf55e34ff587968c5b1f1ec6b6ae39d2668a66ecba3633163a21fc5R86 - partly due to the confusion fixed with the above commit.

Fixes https://github.com/eyre-rs/eyre/issues/147