### PR TITLE
Release 0.6.12

### DIFF
--- a/eyre/CHANGELOG.md
+++ b/eyre/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.6.12] - 2024-01-31
+### Fixed
+- Unsound cast to invalid type during Report downcast [by ten3roberts](https://github.com/eyre-rs/eyre/pull/143)
+
 ## [0.6.11] - 2023-12-13
 ### Fixed
 - stale references to `Error` in docstrings [by birkenfeld](https://github.com/eyre-rs/eyre/pull/87)

--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eyre"
-version = "0.6.11"
+version = "0.6.12"
 authors = ["David Tolnay <dtolnay@gmail.com>", "Jane Lusby <jlusby42@gmail.com>"]
 description = "Flexible concrete Error Reporting type built on std::error::Error with customizable Reports"
 documentation = "https://docs.rs/eyre"

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -318,7 +318,7 @@
 //! [`simple-eyre`]: https://github.com/eyre-rs/simple-eyre
 //! [`color-spantrace`]: https://github.com/eyre-rs/color-spantrace
 //! [`color-backtrace`]: https://github.com/athre0z/color-backtrace
-#![doc(html_root_url = "https://docs.rs/eyre/0.6.11")]
+#![doc(html_root_url = "https://docs.rs/eyre/0.6.12")]
 #![cfg_attr(
     nightly,
     feature(rustdoc_missing_doc_code_examples),


### PR DESCRIPTION
Adds a hotfix missed in the last version, mistake by us as the previous release happened on the same day as the bugfix.

@yaahc, does everything look correct? Merging into the `releas-0.6` branch as master contains breaking changes and is not linear with this