### PR TITLE
 Fix ci breaking due to new dependencies and rustc changes (backport to master)

### DIFF
--- a/color-eyre/tests/theme.rs
+++ b/color-eyre/tests/theme.rs
@@ -124,6 +124,8 @@ fn test_panic_backwards_compatibility() {
         .args(["run", "--example", "theme_test_helper"])
         .arg("--no-default-features")
         .args(&features)
+        .env("RUSTFLAGS", "-Awarnings")
+        .env("CARGO_FUTURE_INCOMPAT_REPORT_FREQUENCY", "never")
         .output()
         .expect("failed to execute process");
     let target = String::from_utf8(output.stderr).expect("failed to convert output to `String`");
@@ -168,7 +170,7 @@ fn test_backwards_compatibility(target: String, file_name: &str) {
     fn normalize_backtrace(input: &str) -> String {
         input
             .lines()
-            .take_while(|v| !v.contains("core::panic"))
+            .take_while(|v| !v.contains("core::panic") && !v.contains("theme_test_helper::main"))
             .collect::<Vec<_>>()
             .join("\n")
     }

--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -27,7 +27,7 @@ pyo3 = { version = "0.20", optional = true, default-features = false }
 futures = { version = "0.3", default-features = false }
 rustversion = "1.0"
 thiserror = "1.0"
-trybuild = { version = "1.0.19", features = ["diff"] }
+trybuild = { version = "=1.0.83", features = ["diff"] }
 backtrace = "0.3.46"
 anyhow = "1.0.28"
 syn = { version = "2.0", features = ["full"] }


### PR DESCRIPTION
Applies the same fixes that was applied to `color-eyre-0.6` to master, namely the new update to `trybuild` that breaks our MSRV requirement, requiring us to pin the version, as the dependency only bumped the patch version for the updated MRSV.

It also fixes the theme test breaking on windows due to new *before-main* machinery on windows affecting the backtrace. This is fixed by filtering out the functions before and including main(due to no take_until iter adapter in std), but still includes the panicking function call.

There are currently three branches that need/needed this fix

- master: containing latest breaking code for 1.0
- color-eyre-0.6
- release-0.6 (does not include the theme test change as color-eyre is not present there)