### PR TITLE
Don't evaluate 1-argument `ensure!` condition twice

### DIFF
--- a/eyre/src/macros.rs
+++ b/eyre/src/macros.rs
@@ -108,9 +108,7 @@ macro_rules! bail {
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr $(,)?) => {
-        if !$cond {
-            $crate::ensure!($cond, concat!("Condition failed: `", stringify!($cond), "`"))
-        }
+        $crate::ensure!($cond, concat!("Condition failed: `", stringify!($cond), "`"))
     };
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {


### PR DESCRIPTION
`ensure!($cond:expr)` currently expands to two nested `if !$cond {}`.