### PR TITLE
fix(docs): enclose inline code in backticks

### DIFF
--- a/eyre/src/error.rs
+++ b/eyre/src/error.rs
@@ -27,7 +27,7 @@ impl Report {
 
     /// Create a new error object from a printable error message.
     ///
-    /// If the argument implements std::error::Error, prefer `Report::new`
+    /// If the argument implements `std::error::Error`, prefer [`Report::new`]
     /// instead which preserves the underlying error's cause chain and
     /// backtrace. If the argument may or may not implement std::error::Error
     /// now or in the future, use `eyre!(err)` which handles either way

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -417,22 +417,22 @@ pub use WrapErr as Context;
 ///
 /// # Display representations
 ///
-/// When you print an error object using "{}" or to_string(), only the outermost underlying error
-/// is printed, not any of the lower level causes. This is exactly as if you had called the Display
-/// impl of the error from which you constructed your eyre::Report.
+/// When you print an error object using `"{}"` or `to_string()`, only the outermost underlying error
+/// is printed, not any of the lower level causes. This is exactly as if you had called the `Display`
+/// implementation of the error from which you constructed your `eyre::Report`.
 ///
 /// ```console
 /// Failed to read instrs from ./path/to/instrs.json
 /// ```
 ///
 /// To print causes as well using eyre's default formatting of causes, use the
-/// alternate selector "{:#}".
+/// alternate selector `"{:#}"`.
 ///
 /// ```console
 /// Failed to read instrs from ./path/to/instrs.json: No such file or directory (os error 2)
 /// ```
 ///
-/// The Debug format "{:?}" includes your backtrace if one was captured. Note
+/// The Debug format `"{:?}"` includes your backtrace if one was captured. Note
 /// that this is the representation you get by default if you return an error
 /// from `fn main` instead of printing it explicitly yourself.
 ///
@@ -458,7 +458,7 @@ pub use WrapErr as Context;
 ///    7: _start
 /// ```
 ///
-/// To see a conventional struct-style Debug representation, use "{:#?}".
+/// To see a conventional struct-style Debug representation, use `"{:#?}"`.
 ///
 /// ```console
 /// Error {
@@ -1271,7 +1271,7 @@ pub trait ContextCompat<T>: context::private::Sealed {
         F: FnOnce() -> D;
 }
 
-/// Equivalent to Ok::<_, eyre::Error>(value).
+/// Equivalent to `Ok::<_, eyre::Error>(value)`.
 ///
 /// This simplifies creation of an eyre::Result in places where type inference
 /// cannot deduce the `E` type of the result &mdash; without needing to write


### PR DESCRIPTION
Fixes #169

Besides enclosing inline code in backticks, I also made two tiny documentation improvements - please let me know if you want them undone:

- In the `Report::msg` docs, the user is referred to `Report::new`. I changed this from plain inline code into a link.
- I expanded _"`Display` impl"_ to _"`Display` implementation"_, since `impl` is a Rust token, but 
  - _"`Display` `impl`"_ looked silly, and 
  - _"`impl Display`"_ disturbed the flow of reading.