### PR TITLE
Fix overly strict clippy lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
-
+          args: --all-targets --all-features -- -D clippy::style -D clippy::suspiscious -D clippy::complexity
   miri:
     name: Miri
     runs-on: ubuntu-latest


### PR DESCRIPTION
Deny style, suspicious and complexity categories, rather than all warnings

If we find issues that could have been caught by a clippy lint we can add that lint on as *deny* too, as for now, they still appear as warnings but won't prevent CI from running.

This most notably fixes random CI breakages when clippy/rust updates and introduces new warn level lints