### PR TITLE
Fix typo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D clippy::style -D clippy::suspiscious -D clippy::complexity
+          args: --all-targets --all-features -- -D clippy::style -D clippy::suspicious -D clippy::complexity
   miri:
     name: Miri
     runs-on: ubuntu-latest

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -624,7 +624,6 @@ fn capture_handler(error: &(dyn StdError + 'static)) -> Box<dyn EyreHandler> {
 }
 
 impl dyn EyreHandler {
-    ///
     pub fn is<T: EyreHandler>(&self) -> bool {
         // Get `TypeId` of the type this function is instantiated with.
         let t = core::any::TypeId::of::<T>();
@@ -636,7 +635,6 @@ impl dyn EyreHandler {
         t == concrete
     }
 
-    ///
     pub fn downcast_ref<T: EyreHandler>(&self) -> Option<&T> {
         if self.is::<T>() {
             unsafe { Some(&*(self as *const dyn EyreHandler as *const T)) }
@@ -645,7 +643,6 @@ impl dyn EyreHandler {
         }
     }
 
-    ///
     pub fn downcast_mut<T: EyreHandler>(&mut self) -> Option<&mut T> {
         if self.is::<T>() {
             unsafe { Some(&mut *(self as *mut dyn EyreHandler as *mut T)) }


### PR DESCRIPTION
The lint group is `clippy::suspicious`, not `clippy::suspiscious`

https://github.com/eyre-rs/eyre/actions/runs/9112483886/job/25051828362#step:5:176

```
warning[E0602]: unknown lint: `clippy::suspiscious`
Warning:   |
  = help: did you mean: `clippy::suspicious`
  = note: requested on the command line with `-D clippy::suspiscious`
  = note: `#[warn(unknown_lints)]` on by default
```