### PR TITLE
Fix ambiguous methods

### DIFF
--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -636,7 +636,7 @@ impl dyn EyreHandler {
         t == concrete
     }
 
-    /// Downcast the handler to a contcrete type `T`
+    /// Downcast the handler to a concrete type `T`
     pub fn downcast_ref<T: EyreHandler>(&self) -> Option<&T> {
         if self.is::<T>() {
             unsafe { Some(&*(self as *const dyn EyreHandler as *const T)) }

--- a/eyre/tests/test_location.rs
+++ b/eyre/tests/test_location.rs
@@ -133,36 +133,6 @@ fn test_with_context() {
 
 #[cfg(feature = "anyhow")]
 #[test]
-fn test_option_compat_wrap_err() {
-    let _ = eyre::set_hook(Box::new(|_e| {
-        let expected_location = file!();
-        Box::new(LocationHandler::new(expected_location))
-    }));
-
-    use eyre::ContextCompat;
-    let err = None::<()>.context("oopsie").unwrap_err();
-
-    // should panic if the location isn't in our crate
-    println!("{:?}", err);
-}
-
-#[cfg(feature = "anyhow")]
-#[test]
-fn test_option_compat_wrap_err_with() {
-    let _ = eyre::set_hook(Box::new(|_e| {
-        let expected_location = file!();
-        Box::new(LocationHandler::new(expected_location))
-    }));
-
-    use eyre::ContextCompat;
-    let err = None::<()>.with_context(|| "oopsie").unwrap_err();
-
-    // should panic if the location isn't in our crate
-    println!("{:?}", err);
-}
-
-#[cfg(feature = "anyhow")]
-#[test]
 fn test_option_compat_context() {
     let _ = eyre::set_hook(Box::new(|_e| {
         let expected_location = file!();

--- a/eyre/tests/test_location.rs
+++ b/eyre/tests/test_location.rs
@@ -100,13 +100,12 @@ fn test_option_ok_or_eyre() {
 #[cfg(feature = "anyhow")]
 #[test]
 fn test_context() {
-    use eyre::ContextCompat;
-
     let _ = eyre::set_hook(Box::new(|_e| {
         let expected_location = file!();
         Box::new(LocationHandler::new(expected_location))
     }));
 
+    use eyre::ContextCompat;
     let err = read_path("totally_fake_path")
         .context("oopsie")
         .unwrap_err();
@@ -118,13 +117,12 @@ fn test_context() {
 #[cfg(feature = "anyhow")]
 #[test]
 fn test_with_context() {
-    use eyre::ContextCompat;
-
     let _ = eyre::set_hook(Box::new(|_e| {
         let expected_location = file!();
         Box::new(LocationHandler::new(expected_location))
     }));
 
+    use eyre::ContextCompat;
     let err = read_path("totally_fake_path")
         .with_context(|| "oopsie")
         .unwrap_err();


### PR DESCRIPTION
# style: consistently place `use eyre::ContextCompat` in location test
    
Fixes
- https://github.com/eyre-rs/eyre/pull/150#discussion_r1545645111

# chore: remove obsolete `impl ContextCompat for Option` location tests

Fixes
- https://github.com/eyre-rs/eyre/pull/150#discussion_r1658544995,
- https://github.com/eyre-rs/eyre/pull/150#discussion_r1658545850


