### PR TITLE
chore!: remove `anyhow` from default features

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,12 @@ vice-versa by `re-exporting` all of the renamed APIs with the names used in
 
 ### Disabling the compatibility layer
 
-The `anyhow` compatibility layer is enabled by default.
-If you do not need anyhow compatibility, it is advisable
-to disable the `"anyhow"` feature:
+The `anyhow` compatibility layer is disabled by default.
+If you need anyhow compatibility, it is advisable
+to enable the `"anyhow"` feature:
 
 ```toml
-eyre = { version = "0.6", default-features = false, features = ["auto-install", "track-caller"] }
+eyre = { version = "0.6", features = ["anyhow"] }
 ```
 
 ### `Context` and `Option`

--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -13,7 +13,7 @@ readme = { workspace = true }
 rust-version = { workspace = true }
 
 [features]
-default = ["anyhow", "auto-install", "track-caller"]
+default = ["auto-install", "track-caller"]
 anyhow = []
 auto-install = []
 track-caller = []

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -267,12 +267,12 @@
 //!
 //! ### Disabling the compatibility layer
 //!
-//! The `anyhow` compatibility layer is enabled by default.
-//! If you do not need anyhow compatibility, it is advisable
-//! to disable the `"anyhow"` feature:
+//! The `anyhow` compatibility layer is disabled by default.
+//! If you need anyhow compatibility, it is advisable
+//! to enable the `"anyhow"` feature:
 //!
 //! ```toml
-//! eyre = { version = "0.6", default-features = false, features = ["auto-install", "track-caller"] }
+//! eyre = { version = "0.6", features = ["anyhow"] }
 //! ```
 //!
 //! ### `Context` and `Option`


### PR DESCRIPTION
[#131][131] introduced a new anyhow default feature flag to allow users to hide aliased exports such as `eyre::Error` and `eyre::Context`.

This changeset removes `anyhow` from the list of default features, making the compatibility layer with the anyhow crate opt-in.

Implements [#136][136].

[131]: https://github.com/eyre-rs/eyre/issues/131
[136]: https://github.com/eyre-rs/eyre/issues/136

BREAKING CHANGE: Removing a default feature is a breaking change.