### PR TITLE
chore!: remove alias exports `DefaultContext` and `EyreContext`

### DIFF
--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -389,12 +389,6 @@ pub use eyre as format_err;
 pub use eyre as anyhow;
 use once_cell::sync::OnceCell;
 use ptr::OwnedPtr;
-#[cfg(feature = "anyhow")]
-#[doc(hidden)]
-pub use DefaultHandler as DefaultContext;
-#[cfg(feature = "anyhow")]
-#[doc(hidden)]
-pub use EyreHandler as EyreContext;
 #[doc(hidden)]
 pub use Report as ErrReport;
 /// Compatibility re-export of `Report` for interop with `anyhow`


### PR DESCRIPTION
`DefaultContext` and `EyreContext` exist as alias exports enabled by the `anyhow` feature.

However, they are unused within `eyre`; neither are handlers of such names exposed by `anyhow`.

This changeset removes both above mentioned handler aliases.

Closes [#135][135].

[135]: https://github.com/eyre-rs/eyre/issues/135

BREAKING CHANGE: The alias exports are undocumented but nevertheless part of the crate's public API.