### PR TITLE
fix(color_eyre): build warnings

### DIFF
--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -11,39 +11,6 @@ use std::env;
 use std::fmt::Write as _;
 use std::{fmt, path::PathBuf, sync::Arc};
 
-#[derive(Debug)]
-struct InstallError;
-
-impl fmt::Display for InstallError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("could not install the BacktracePrinter as another was already installed")
-    }
-}
-
-impl std::error::Error for InstallError {}
-
-#[derive(Debug)]
-struct InstallThemeError;
-
-impl fmt::Display for InstallThemeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("could not set the provided `Theme` globally as another was already set")
-    }
-}
-
-impl std::error::Error for InstallThemeError {}
-
-#[derive(Debug)]
-struct InstallColorSpantraceThemeError;
-
-impl fmt::Display for InstallColorSpantraceThemeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("could not set the provided `Theme` via `color_spantrace::set_theme` globally as another was already set")
-    }
-}
-
-impl std::error::Error for InstallColorSpantraceThemeError {}
-
 /// A struct that represents a theme that is used by `color_eyre`
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Theme {

--- a/color-eyre/src/writers.rs
+++ b/color-eyre/src/writers.rs
@@ -28,11 +28,13 @@ impl<W> WriterExt for W {
     }
 }
 
+#[cfg(feature = "issue-url")]
 pub(crate) trait DisplayExt: Sized + Display {
     fn with_header<H: Display>(self, header: H) -> Header<Self, H>;
     fn with_footer<F: Display>(self, footer: F) -> Footer<Self, F>;
 }
 
+#[cfg(feature = "issue-url")]
 impl<T> DisplayExt for T
 where
     T: Display,
@@ -80,11 +82,13 @@ where
     }
 }
 
+#[cfg(feature = "issue-url")]
 pub(crate) struct FooterWriter<W> {
     inner: W,
     had_output: bool,
 }
 
+#[cfg(feature = "issue-url")]
 impl<W> fmt::Write for FooterWriter<W>
 where
     W: fmt::Write,
@@ -98,6 +102,7 @@ where
     }
 }
 
+#[cfg(feature = "issue-url")]
 #[allow(explicit_outlives_requirements)]
 pub(crate) struct Footer<B, H>
 where
@@ -108,6 +113,7 @@ where
     footer: H,
 }
 
+#[cfg(feature = "issue-url")]
 impl<B, H> fmt::Display for Footer<B, H>
 where
     B: Display,
@@ -129,6 +135,7 @@ where
     }
 }
 
+#[cfg(feature = "issue-url")]
 #[allow(explicit_outlives_requirements)]
 pub(crate) struct Header<B, H>
 where
@@ -139,6 +146,7 @@ where
     h: H,
 }
 
+#[cfg(feature = "issue-url")]
 impl<B, H> fmt::Display for Header<B, H>
 where
     B: Display,


### PR DESCRIPTION
Remove structs that are unused and have been migrated to use the eyre
versions of the same:
- color_eyre::config::InstallError -> eyre::InstallError
- color_eyre::config::InstallThemeError -> eyre::InstallThemeError
- color_eyre::config::InstallColorSpantraceThemeError -> no equivalent

Add cfg guards to the DisplayExt, FooterWriter, Footer, and Header
to prevent unused warnings when the issue-url feature is not enabled.

---

Warnings:
```
   Compiling color-eyre v0.6.2 (/Users/joshka/local/eyre/color-eyre)
warning: struct `InstallError` is never constructed
   --> color-eyre/src/config.rs:15:8
    |
15  | struct InstallError;
    |        ^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> color-eyre/src/lib.rs:352:5
    |
352 |     unused,
    |     ^^^^^^
    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`

warning: struct `InstallThemeError` is never constructed
  --> color-eyre/src/config.rs:26:8
   |
26 | struct InstallThemeError;
   |        ^^^^^^^^^^^^^^^^^

warning: struct `InstallColorSpantraceThemeError` is never constructed
  --> color-eyre/src/config.rs:37:8
   |
37 | struct InstallColorSpantraceThemeError;
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: trait `DisplayExt` is never used
  --> color-eyre/src/writers.rs:31:18
   |
31 | pub(crate) trait DisplayExt: Sized + Display {
   |                  ^^^^^^^^^^

warning: struct `FooterWriter` is never constructed
  --> color-eyre/src/writers.rs:83:19
   |
83 | pub(crate) struct FooterWriter<W> {
   |                   ^^^^^^^^^^^^

warning: struct `Footer` is never constructed
   --> color-eyre/src/writers.rs:102:19
    |
102 | pub(crate) struct Footer<B, H>
    |                   ^^^^^^

warning: struct `Header` is never constructed
   --> color-eyre/src/writers.rs:133:19
    |
133 | pub(crate) struct Header<B, H>
    |                   ^^^^^^

warning: `color-eyre` (lib) generated 7 warnings
```