### PR TITLE
feat(color-eyre): Add pre-hook callbacks

### DIFF
--- a/color-eyre/examples/pre_hook_callbacks.rs
+++ b/color-eyre/examples/pre_hook_callbacks.rs
@@ -1,0 +1,49 @@
+use color_eyre::eyre::Report;
+use tracing::instrument;
+
+#[instrument]
+fn main() -> Result<(), Report> {
+    #[cfg(feature = "capture-spantrace")]
+    install_tracing();
+
+    color_eyre::config::HookBuilder::default()
+        .add_pre_hook_callback(Box::new(|| {
+            eprintln!("This is a pre hook callback");
+        }))
+        .install()
+        .unwrap();
+
+    read_config();
+
+    Ok(())
+}
+
+#[cfg(feature = "capture-spantrace")]
+fn install_tracing() {
+    use tracing_error::ErrorLayer;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let fmt_layer = fmt::layer().with_target(false);
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .with(ErrorLayer::default())
+        .init();
+}
+
+#[instrument]
+fn read_file(path: &str) {
+    if let Err(e) = std::fs::read_to_string(path) {
+        panic!("{}", e);
+    }
+}
+
+#[instrument]
+fn read_config() {
+    read_file("fake_file")
+}

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -11,39 +11,6 @@ use std::env;
 use std::fmt::Write as _;
 use std::{fmt, path::PathBuf, sync::Arc};
 
-#[derive(Debug)]
-struct InstallError;
-
-impl fmt::Display for InstallError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("could not install the BacktracePrinter as another was already installed")
-    }
-}
-
-impl std::error::Error for InstallError {}
-
-#[derive(Debug)]
-struct InstallThemeError;
-
-impl fmt::Display for InstallThemeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("could not set the provided `Theme` globally as another was already set")
-    }
-}
-
-impl std::error::Error for InstallThemeError {}
-
-#[derive(Debug)]
-struct InstallColorSpantraceThemeError;
-
-impl fmt::Display for InstallColorSpantraceThemeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("could not set the provided `Theme` via `color_spantrace::set_theme` globally as another was already set")
-    }
-}
-
-impl std::error::Error for InstallColorSpantraceThemeError {}
-
 /// A struct that represents a theme that is used by `color_eyre`
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Theme {

--- a/color-eyre/src/writers.rs
+++ b/color-eyre/src/writers.rs
@@ -28,11 +28,13 @@ impl<W> WriterExt for W {
     }
 }
 
+#[cfg(feature = "issue-url")]
 pub(crate) trait DisplayExt: Sized + Display {
     fn with_header<H: Display>(self, header: H) -> Header<Self, H>;
     fn with_footer<F: Display>(self, footer: F) -> Footer<Self, F>;
 }
 
+#[cfg(feature = "issue-url")]
 impl<T> DisplayExt for T
 where
     T: Display,
@@ -80,11 +82,13 @@ where
     }
 }
 
+#[cfg(feature = "issue-url")]
 pub(crate) struct FooterWriter<W> {
     inner: W,
     had_output: bool,
 }
 
+#[cfg(feature = "issue-url")]
 impl<W> fmt::Write for FooterWriter<W>
 where
     W: fmt::Write,
@@ -98,6 +102,7 @@ where
     }
 }
 
+#[cfg(feature = "issue-url")]
 #[allow(explicit_outlives_requirements)]
 pub(crate) struct Footer<B, H>
 where
@@ -108,6 +113,7 @@ where
     footer: H,
 }
 
+#[cfg(feature = "issue-url")]
 impl<B, H> fmt::Display for Footer<B, H>
 where
     B: Display,
@@ -129,6 +135,7 @@ where
     }
 }
 
+#[cfg(feature = "issue-url")]
 #[allow(explicit_outlives_requirements)]
 pub(crate) struct Header<B, H>
 where
@@ -139,6 +146,7 @@ where
     h: H,
 }
 
+#[cfg(feature = "issue-url")]
 impl<B, H> fmt::Display for Header<B, H>
 where
     B: Display,


### PR DESCRIPTION
This adds the ability to add custom pre-hook callbacks to the panic /
error hook. These callbacks will be called before the panic / error hook
is called and can be used to print additional information or perform
other actions before the panic / error hook is called (such as clearing
the terminal, printing a message, etc.)

Often in an interactive TUI application, the terminal state is set to
raw mode (where newlines do not automatically cause the cursor to move
to the start of the next line), and is in the alternate screen buffer
(which is a separate screen buffer that is used for full-screen apps).

This means that when a panic occurs, the terminal will display the panic
message all janky. By adding a pre-hook callback that restores the
terminal state to normal mode, the panic message can be displayed
properly.

```rust
HookBuilder::default()
    .add_pre_hook_callback(Box::new(|| eprintln!("pre-hook callback")))
    .install()?
```

In a crossterm based app, that might look like the following instead of
the more lengthy code in https://ratatui.rs/recipes/apps/color-eyre/

```rust
use crossterm::terminal::{disable_raw_mode, LeaveAlternateScreen};

HookBuilder::default()
    .add_pre_hook_callback(Box::new(|| {
        let _ = disable_raw_mode();
        let _ = execute!(stdout(), LeaveAlternateScreen);
    }))
    .install()?
```