### PR TITLE
feat: reversed stacktraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ name = "eyre"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "autocfg",
  "backtrace",
  "futures",
  "indenter",

--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -387,6 +387,7 @@ pub struct HookBuilder {
     filters: Vec<Box<FilterCallback>>,
     capture_span_trace_by_default: bool,
     display_env_section: bool,
+    reversed_stacktrace: bool,
     #[cfg(feature = "track-caller")]
     display_location_section: bool,
     panic_section: Option<Box<dyn Display + Send + Sync + 'static>>,
@@ -430,6 +431,7 @@ impl HookBuilder {
             filters: vec![],
             capture_span_trace_by_default: false,
             display_env_section: true,
+            reversed_stacktrace: false,
             #[cfg(feature = "track-caller")]
             display_location_section: true,
             panic_section: None,
@@ -616,9 +618,15 @@ impl HookBuilder {
         self
     }
 
-    /// Configures the enviroment varible info section and whether or not it is displayed
+    /// Configures the environment variable info section and whether or not it is displayed
     pub fn display_env_section(mut self, cond: bool) -> Self {
         self.display_env_section = cond;
+        self
+    }
+
+    /// Configures the whether or not the stacktrace frame order is reversed
+    pub fn reversed_stacktrace(mut self, cond: bool) -> Self {
+        self.reversed_stacktrace = cond;
         self
     }
 
@@ -697,6 +705,7 @@ impl HookBuilder {
             #[cfg(feature = "capture-spantrace")]
             capture_span_trace_by_default: self.capture_span_trace_by_default,
             display_env_section: self.display_env_section,
+            reversed_stacktrace: self.reversed_stacktrace,
             panic_message: self
                 .panic_message
                 .unwrap_or_else(|| Box::new(DefaultPanicMessage(theme))),
@@ -714,6 +723,7 @@ impl HookBuilder {
             #[cfg(feature = "capture-spantrace")]
             capture_span_trace_by_default: self.capture_span_trace_by_default,
             display_env_section: self.display_env_section,
+            reversed_stacktrace: self.reversed_stacktrace,
             #[cfg(feature = "track-caller")]
             display_location_section: self.display_location_section,
             theme,
@@ -914,6 +924,7 @@ pub struct PanicHook {
     #[cfg(feature = "capture-spantrace")]
     capture_span_trace_by_default: bool,
     display_env_section: bool,
+    reversed_stacktrace: bool,
     #[cfg(feature = "issue-url")]
     issue_url: Option<String>,
     #[cfg(feature = "issue-url")]
@@ -931,6 +942,7 @@ impl PanicHook {
             filters: &self.filters,
             inner: trace,
             theme: self.theme,
+            reversed_stacktrace: self.reversed_stacktrace,
         }
     }
 
@@ -993,6 +1005,7 @@ pub struct EyreHook {
     #[cfg(feature = "capture-spantrace")]
     capture_span_trace_by_default: bool,
     display_env_section: bool,
+    reversed_stacktrace: bool,
     #[cfg(feature = "track-caller")]
     display_location_section: bool,
     theme: Theme,
@@ -1037,6 +1050,7 @@ impl EyreHook {
             span_trace,
             sections: Vec::new(),
             display_env_section: self.display_env_section,
+            reversed_stacktrace: self.reversed_stacktrace,
             #[cfg(feature = "track-caller")]
             display_location_section: self.display_location_section,
             #[cfg(feature = "issue-url")]
@@ -1073,6 +1087,7 @@ pub(crate) struct BacktraceFormatter<'a> {
     pub(crate) filters: &'a [Box<FilterCallback>],
     pub(crate) inner: &'a backtrace::Backtrace,
     pub(crate) theme: Theme,
+    pub(crate) reversed_stacktrace: bool,
 }
 
 impl fmt::Display for BacktraceFormatter<'_> {
@@ -1114,6 +1129,10 @@ impl fmt::Display for BacktraceFormatter<'_> {
         // Don't let filters mess with the order.
         filtered_frames.sort_by_key(|x| x.n);
 
+        if self.reversed_stacktrace {
+            filtered_frames.reverse();
+        }
+
         let mut buf = String::new();
 
         macro_rules! print_hidden {
@@ -1136,9 +1155,13 @@ impl fmt::Display for BacktraceFormatter<'_> {
             };
         }
 
-        let mut last_n = 0;
+        let mut last_n = if self.reversed_stacktrace {
+            frames.last().unwrap().n
+        } else {
+            0
+        };
         for frame in &filtered_frames {
-            let frame_delta = frame.n - last_n - 1;
+            let frame_delta = frame.n.abs_diff(last_n) - 1;
             if frame_delta != 0 {
                 print_hidden!(frame_delta);
             }
@@ -1147,9 +1170,13 @@ impl fmt::Display for BacktraceFormatter<'_> {
         }
 
         let last_filtered_n = filtered_frames.last().unwrap().n;
-        let last_unfiltered_n = frames.last().unwrap().n;
-        if last_filtered_n < last_unfiltered_n {
-            print_hidden!(last_unfiltered_n - last_filtered_n);
+        let last_unfiltered_n = if self.reversed_stacktrace {
+            0
+        } else {
+            frames.last().unwrap().n
+        };
+        if last_filtered_n != last_unfiltered_n {
+            print_hidden!(last_unfiltered_n.abs_diff(last_filtered_n));
         }
 
         Ok(())

--- a/color-eyre/src/handler.rs
+++ b/color-eyre/src/handler.rs
@@ -37,6 +37,7 @@ impl Handler {
             filters: &self.filters,
             inner: trace,
             theme: self.theme,
+            reversed_stacktrace: self.reversed_stacktrace,
         }
     }
 }

--- a/color-eyre/src/lib.rs
+++ b/color-eyre/src/lib.rs
@@ -404,6 +404,7 @@ pub struct Handler {
     display_env_section: bool,
     #[cfg(feature = "track-caller")]
     display_location_section: bool,
+    reversed_stacktrace: bool,
     #[cfg(feature = "issue-url")]
     issue_url: Option<String>,
     #[cfg(feature = "issue-url")]

--- a/color-eyre/tests/stacktrace.rs
+++ b/color-eyre/tests/stacktrace.rs
@@ -1,0 +1,48 @@
+use color_eyre::eyre;
+use eyre::eyre;
+
+fn foo5() -> eyre::Report {
+    foo4()
+}
+fn foo4() -> eyre::Report {
+    foo3()
+}
+fn foo3() -> eyre::Report {
+    foo2()
+}
+fn foo2() -> eyre::Report {
+    foo1()
+}
+fn foo1() -> eyre::Report {
+    eyre::eyre!("error occured")
+}
+
+#[test]
+fn stacktrace_forward() {
+    color_eyre::config::HookBuilder::default()
+        .display_env_section(true)
+        .reversed_stacktrace(false)
+        .install()
+        .unwrap();
+
+    let report = foo5();
+
+    let report = format!("{:?}", report);
+    println!("{}", report);
+    assert!(report.contains("RUST_BACKTRACE"));
+}
+
+#[test]
+fn stacktrace_reversed() {
+    color_eyre::config::HookBuilder::default()
+        .display_env_section(true)
+        .reversed_stacktrace(true)
+        .install()
+        .unwrap();
+
+    let report = foo5();
+
+    let report = format!("{:?}", report);
+    println!("{}", report);
+    assert!(report.contains("RUST_BACKTRACE"));
+}


### PR DESCRIPTION
This PR adds `reversed_stacktrace` as a configurable option that defaults to false, which keeps the default printing identical to the status quo.

Forward:

<img width="757" alt="image" src="https://github.com/user-attachments/assets/ad5b8ac2-f984-42c3-b6f1-30102239cc09">

Reversed:

<img width="757" alt="image" src="https://github.com/user-attachments/assets/9aef453a-a93f-45dc-8048-f11cdbde1cda">

This is a follow up to this issue:  https://github.com/eyre-rs/color-eyre/issues/154