### PR TITLE
add support to specify verbosity in HookBuilder

### DIFF
--- a/color-eyre/src/config.rs
+++ b/color-eyre/src/config.rs
@@ -618,6 +618,12 @@ impl HookBuilder {
         self
     }
 
+    /// Configures the verbosity to use. Overrides environment variables.
+    pub fn verbosity(mut self, verbosity: Verbosity) -> Self {
+        self.verbosity = Some(verbosity);
+        self
+    }
+
     /// Configures the enviroment varible info section and whether or not it is displayed
     pub fn display_env_section(mut self, cond: bool) -> Self {
         self.display_env_section = cond;
@@ -1164,10 +1170,17 @@ impl fmt::Display for BacktraceFormatter<'_> {
     }
 }
 
+/// Verbosity of error and panic messages.
+///
+/// For previews or more information see the [crate documentation](crate#multiple-report-format-verbosity-levels)
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-pub(crate) enum Verbosity {
+pub enum Verbosity {
+    /// Minimal verbosity that does not include a `Backtrace`.
     Minimal,
+    /// The "short format" which additionally captures a `Backtrace`.
     Medium,
+    /// The full verbose format which will include context of the source files where the error
+    /// originated from, assuming it can find them on the disk.
     Full,
 }
 

--- a/color-eyre/src/writers.rs
+++ b/color-eyre/src/writers.rs
@@ -189,9 +189,9 @@ pub(crate) struct EnvSection<'a> {
 impl fmt::Display for EnvSection<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let v = if std::thread::panicking() {
-            panic_verbosity()
+            panic_verbosity(None)
         } else {
-            lib_verbosity()
+            lib_verbosity(None)
         };
         write!(f, "{}", BacktraceOmited(!self.bt_captured))?;
 


### PR DESCRIPTION
In situations where setting the environment is [unsafe](https://doc.rust-lang.org/std/env/fn.set_var.html#safety) it would be more convenient to manually specify the verbosity without using the environment at all.