### PR TITLE
emit rustc-check-cfg info and fix doc_lazy_continuation clippy warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 **/*.rs.bk
-tags

--- a/color-spantrace/build.rs
+++ b/color-spantrace/build.rs
@@ -20,6 +20,9 @@ enum Toolchain {
 
 impl Toolchain {
     fn set_feature(self) {
+        println!("cargo:rustc-check-cfg=cfg(nightly)");
+        println!("cargo:rustc-check-cfg=cfg(beta)");
+        println!("cargo:rustc-check-cfg=cfg(stable)");
         match self {
             Toolchain::Nightly => println!("cargo:rustc-cfg=nightly"),
             Toolchain::Beta => println!("cargo:rustc-cfg=beta"),

--- a/eyre/build.rs
+++ b/eyre/build.rs
@@ -5,6 +5,13 @@ use std::{
 };
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
+    println!("cargo:rustc-check-cfg=cfg(track_caller)");
+    println!("cargo:rustc-check-cfg=cfg(generic_member_access)");
+    println!("cargo:rustc-check-cfg=cfg(eyre_no_fmt_args_capture)");
+    println!("cargo:rustc-check-cfg=cfg(backtrace)");
+    println!("cargo:rustc-check-cfg=cfg(eyre_no_fmt_arguments_as_str)");
+    println!("cargo:rustc-check-cfg=cfg(doc_cfg)");
     let ac = autocfg::new();
 
     // https://github.com/rust-lang/rust/issues/99301 [nightly]

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -39,16 +39,16 @@
 //! to avoid using `eyre::Report` as your public error type.
 //!
 //! - You export an undocumented error interface that is otherwise still
-//! accessible via downcast, making it hard for users to react to specific
-//! errors while not preventing them from depending on details you didn't mean
-//! to make part of your public API.
+//!   accessible via downcast, making it hard for users to react to specific
+//!   errors while not preventing them from depending on details you didn't mean
+//!   to make part of your public API.
 //!   - This in turn makes the error types of all libraries you use a part of
-//!   your public API as well, and makes changing any of those libraries into
-//!   undetectable runtime breakage.
+//!     your public API as well, and makes changing any of those libraries into
+//!     undetectable runtime breakage.
 //! - If many of your errors are constructed from strings, you encourage your
-//! users to use string comparison for reacting to specific errors, which is
-//! brittle and turns updating error messages into potentially undetectable
-//! runtime breakage.
+//!   users to use string comparison for reacting to specific errors, which is
+//!   brittle and turns updating error messages into potentially undetectable
+//!   runtime breakage.
 //!
 //! ## Details
 //!


### PR DESCRIPTION
This should resolve clippy warnings on master