### PR TITLE
Bump color-eyre to 0.6.3, color-spantrace to 0.2.2 to publish owo-colors bump

### DIFF
--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.3"
 description = "An error report handler for panics and eyre::Reports for colorful, consistent, and well formatted error reports for all kinds of errors."
 documentation = "https://docs.rs/color-eyre"
 

--- a/color-spantrace/Cargo.toml
+++ b/color-spantrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color-spantrace"
-version = "0.2.1"
+version = "0.2.2"
 description = "A pretty printer for tracing_error::SpanTrace based on color-backtrace"
 documentation = "https://docs.rs/color-spantrace"
 


### PR DESCRIPTION
owo-colors has a potential soundness bug, which I'm attempting to fix in https://github.com/jam1garner/owo-colors/pull/131. However, a lot of crates rely on the 3.x series, which may not get patched. Preemptively updating them, would appreciate a release!!