### PR TITLE
switch from `once_cell` to `std::sync::OnceLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,14 +116,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ansi-parser",
  "backtrace",
  "color-spantrace",
  "eyre",
  "indenter",
- "once_cell",
  "owo-colors",
  "pretty_assertions",
  "thiserror",
@@ -136,10 +135,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ansi-parser",
- "once_cell",
  "owo-colors",
  "tracing",
  "tracing-core",
@@ -178,7 +176,6 @@ dependencies = [
  "backtrace",
  "futures",
  "indenter",
- "once_cell",
  "pyo3",
  "rustversion",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = "1.65.0"
 
 [workspace.dependencies]
 indenter = "0.3.0"
-once_cell = "1.18.0"
 owo-colors = "4.0"
 autocfg = "1.0"
 

--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -24,7 +24,6 @@ backtrace = { version = "0.3.59" }
 indenter = { workspace = true }
 owo-colors = { workspace = true }
 color-spantrace = { version = "0.2", path = "../color-spantrace", optional = true }
-once_cell = { workspace = true }
 url = { version = "2.1.1", optional = true }
 
 [dev-dependencies]

--- a/color-spantrace/Cargo.toml
+++ b/color-spantrace/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = { workspace = true }
 tracing-error = "0.2.0"
 tracing-core = "0.1.21"
 owo-colors = { workspace = true }
-once_cell = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.4"

--- a/color-spantrace/src/lib.rs
+++ b/color-spantrace/src/lib.rs
@@ -85,15 +85,15 @@
     unused_parens,
     while_true
 )]
-use once_cell::sync::OnceCell;
 use owo_colors::{style, Style};
 use std::env;
 use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::sync::OnceLock;
 use tracing_error::SpanTrace;
 
-static THEME: OnceCell<Theme> = OnceCell::new();
+static THEME: OnceLock<Theme> = OnceLock::new();
 
 /// A struct that represents theme that is used by `color_spantrace`
 #[derive(Debug, Copy, Clone, Default)]

--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -20,7 +20,6 @@ track-caller = []
 
 [dependencies]
 indenter = { workspace = true }
-once_cell = { workspace = true }
 pyo3 = { version = "0.20", optional = true, default-features = false }
 
 [build-dependencies]

--- a/eyre/src/lib.rs
+++ b/eyre/src/lib.rs
@@ -387,8 +387,8 @@ pub use eyre as format_err;
 /// Compatibility re-export of `eyre` for interop with `anyhow`
 #[cfg(feature = "anyhow")]
 pub use eyre as anyhow;
-use once_cell::sync::OnceCell;
 use ptr::OwnedPtr;
+use std::sync::OnceLock;
 #[cfg(feature = "anyhow")]
 #[doc(hidden)]
 pub use DefaultHandler as DefaultContext;
@@ -485,7 +485,7 @@ pub struct Report {
 type ErrorHook =
     Box<dyn Fn(&(dyn StdError + 'static)) -> Box<dyn EyreHandler> + Sync + Send + 'static>;
 
-static HOOK: OnceCell<ErrorHook> = OnceCell::new();
+static HOOK: OnceLock<ErrorHook> = OnceLock::new();
 
 /// Error indicating that `set_hook` was unable to install the provided ErrorHook
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
One less dependency is always nice to have, and [OnceLock](https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html) has been stable since 1.70.