### PR TITLE
color-eyre: remove no-longer-existing backtrace feature gimli-symbolize

### DIFF
--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -21,7 +21,7 @@ track-caller = []
 [dependencies]
 eyre = "0.6.1"
 tracing-error = { version = "0.2.0", optional = true }
-backtrace = { version = "0.3.48", features = ["gimli-symbolize"] }
+backtrace = { version = "0.3.48" }
 indenter = { workspace = true }
 owo-colors = { workspace = true }
 color-spantrace = { version = "0.2", optional = true }


### PR DESCRIPTION
Fixes https://github.com/eyre-rs/eyre/issues/214