### PR TITLE
Bump color-eyre to 0.6.4

### DIFF
--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color-eyre"
-version = "0.6.3"
+version = "0.6.4"
 description = "An error report handler for panics and eyre::Reports for colorful, consistent, and well formatted error reports for all kinds of errors."
 documentation = "https://docs.rs/color-eyre"
 


### PR DESCRIPTION
The previous publish was off on a branch, it seems f544fed447df75b1accbc95bc2c26aa8fedc312e