### PR TITLE
bump minimum color-spantrace requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
 
 [[package]]
 name = "eyre"
-version = "0.6.11"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "autocfg",

--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -23,7 +23,7 @@ tracing-error = { version = "0.2.0", optional = true }
 backtrace = { version = "0.3.59" }
 indenter = { workspace = true }
 owo-colors = { workspace = true }
-color-spantrace = { version = "0.2", path = "../color-spantrace", optional = true }
+color-spantrace = { version = "0.2.2", path = "../color-spantrace", optional = true }
 once_cell = { workspace = true }
 url = { version = "2.1.1", optional = true }
 


### PR DESCRIPTION
color-eyre 0.6.4 requires a newer color-spantrace.

I noticed that the Cargo.lock isn't up-to-date regarding eyre. I guess it should be set back to 0.6.11 before a new color-eyre is released.