### PR TITLE
Exclude images from published crate

### DIFF
--- a/color-spantrace/Cargo.toml
+++ b/color-spantrace/Cargo.toml
@@ -3,6 +3,7 @@ name = "color-spantrace"
 version = "0.2.2"
 description = "A pretty printer for tracing_error::SpanTrace based on color-backtrace"
 documentation = "https://docs.rs/color-spantrace"
+include = ["README.md", "src/**/*.rs", "build.rs", "LICENSE-APACHE", "LICENSE-MIT"]
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/color-spantrace/README.md
+++ b/color-spantrace/README.md
@@ -88,11 +88,11 @@ This creates the following output
 
 ### Minimal Format
 
-![minimal format](./pictures/minimal.png)
+![minimal format](https://raw.githubusercontent.com/eyre-rs/eyre/refs/heads/master/color-spantrace/pictures/minimal.png)
 
 ### Full Format
 
-![Full format](./pictures/full.png)
+![Full format](https://raw.githubusercontent.com/eyre-rs/eyre/refs/heads/master/color-spantrace/pictures/full.png)
 
 #### License
 


### PR DESCRIPTION
This commit introduces an explict `include` configuration in the `Cargo.toml` file of `color-spantrace`. That has the effect that it now excludes the two example images from the source code uploaded to crates.io.
The main benifits of this change are:

* It reduces the size of the uploaded tar-ball from 186KB to 12KB, so an over 90% reduction in size. That will reduce the traffic produced by this crate at crates.io by over 350GB in a 90 day period based on the number of downloads listed by crates.io
* It removes a hard to review binary blob from the source code. In combination with the build script such a blob might enable a future supply chain attack. By removing the blob it becomes at least harder to perform a xz-like code injection.

The pictures are only used by the readme. That readme is rendered by crates.io. To keep the rendering there intact the links to the image have been replaced by linkes to the image hosted by github. This removes the need to upload these images to crates.io.