### PR TITLE
Added no-mut-static feature

### DIFF
--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -17,6 +17,7 @@ default = ["anyhow", "auto-install", "track-caller"]
 anyhow = []
 auto-install = []
 track-caller = []
+no-mut-static = []
 
 [dependencies]
 indenter = { workspace = true }


### PR DESCRIPTION
Some targets do not support mutable statics. This feature allows this library to be used with them.

Other options would be to create a rust forward declared function for the hook, but this pr just uses the default implementation.