### PR TITLE
Static error hook

### DIFF
--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = []
 auto-install = []
 track-caller = []
 no-mut-static = []
+static-error-hook = ["no-mut-static"]
 
 [dependencies]
 indenter = { workspace = true }

--- a/eyre/Cargo.toml
+++ b/eyre/Cargo.toml
@@ -17,6 +17,7 @@ default = ["anyhow", "auto-install", "track-caller"]
 anyhow = []
 auto-install = []
 track-caller = []
+no-mut-static = []
 
 [dependencies]
 indenter = { workspace = true }


### PR DESCRIPTION
Adds a static error hook for targets that don't allow mutable statics. 

Exclusive with/stacked on #248.